### PR TITLE
Rounding

### DIFF
--- a/bin/v7d_transform.F90
+++ b/bin/v7d_transform.F90
@@ -1105,19 +1105,18 @@ IF (c_e(istat_proc) .AND. c_e(ostat_proc)) THEN
   ENDIF
 ENDIF
 
+! rounding
+IF (round) THEN
+  CALL rounding(v7d,v7dtmp,level=almost_equal_levels,nostatproc=.TRUE.)
+  CALL delete(v7d)
+  v7d = v7dtmp
+  CALL init(v7dtmp) ! detach it
+end if
 
 ! sort
 IF (comp_sort) THEN
   CALL vol7d_smart_sort(v7d, lsort_time=.TRUE., lsort_timerange=.TRUE., lsort_level=.TRUE.)
 ENDIF
-
-
-if (round) then
-  call rounding(v7d,v7dtmp,level=almost_equal_levels,nostatproc=.true.)
-  CALL delete(v7d)
-  v7d= v7dtmp
-  CALL init(v7dtmp) ! detach it
-end if
 
 
 #ifdef ALCHIMIA

--- a/data/vargrib2bufr.csv
+++ b/data/vargrib2bufr.csv
@@ -160,6 +160,7 @@ B13230,CAPE (invented),J/Kg,200,201,143,255,1.0,0.0
 B13230,CAPE (invented),J/Kg,78,201,143,255,1.0,0.0
 B14018,Downward short-wave radiation flux (surface),W/m^2,200,200,115,0,1.0,0.0
 B14018,Downward short-wave radiation flux (surface),W/m^2,200,200,115,255,1.0,0.0
+B14018,Downward short-wave radiation flux (surface),W/m^2,255,4,7,0,1.0,0.0
 B14019,Surface Albedo,Fraction,200,200,124,255,100.,0.0
 B14019,Surface Albedo,Fraction,200,200,124,0,100.,0.0
 B14019,Surface Albedo,Percent,255,2,84,255,1.0,0.0
@@ -174,8 +175,10 @@ B14193,Instantaneous latent heat flux (invented),W/m^2,200,200,112,0,1.0,0.0
 B14193,Instantaneous latent heat flux (invented),W/m^2,200,200,112,255,1.0,0.0
 B14194,Instantaneous direct solar radiation DWD (invented),W/m^2,200,201,22,255,1.0,0.0
 B14194,Instantaneous direct solar radiation DWD (invented),W/m^2,78,201,22,255,1.0,0.0
+B14194,Instantaneous direct solar radiation (invented),W/m^2,255,4,13,0,1.0,0.0
 B14195,Instantaneous diffuse solar radiation DWD (invented),W/m^2,200,201,23,255,1.0,0.0
 B14195,Instantaneous diffuse solar radiation DWD (invented),W/m^2,78,201,23,255,1.0,0.0
+B14195,Instantaneous diffuse solar radiation (invented),W/m^2,255,4,14,0,1.0,0.0
 B14196,Net long-wave radiation flux (surface),W/m^2,200,200,111,0,1.0,0.0
 B14196,Net long-wave radiation flux (surface),W/m^2,200,200,111,255,1.0,0.0
 B14196,Net long-wave radiation flux (surface),W/m^2,255,2,112,255,1.0,0.0
@@ -184,10 +187,9 @@ B14197,Net short-wave radiation flux (surface),W/m^2,200,200,110,0,1.0,0.0
 B14197,Net short-wave radiation flux (surface),W/m^2,200,200,110,255,1.0,0.0
 B14197,Net short-wave radiation flux (surface),W/m^2,255,2,111,255,1.0,0.0
 B14197,Net short-wave radiation flux (surface),W/m^2,255,4,9,0,1.0,0.0
-B14198,Downward short-wave radiation flux (surface),W/m^2,255,4,7,0,1.0,0.0
-B14199,Upward short-wave radiation flux (surface),W/m^2,255,4,8,0,1.0,0.0
 B14199,Upward short-wave radiation flux (surface),W/m^2,200,200,116,0,1.0,0.0
 B14199,Upward short-wave radiation flux (surface),W/m^2,200,200,116,255,1.0,0.0
+B14199,Upward short-wave radiation flux (surface),W/m^2,255,4,8,0,1.0,0.0
 B14200,Downward long-wave radiation flux (surface),W/m^2,255,5,3,0,1.0,0.0
 B14201,Upward long-wave radiation flux (surface),W/m^2,255,5,4,0,1.0,0.0
 B15192,NO concentration (invented),ppb,200,200,152,0,0.00000000125,0.0

--- a/vol7d/vol7d_class.F90
+++ b/vol7d/vol7d_class.F90
@@ -3059,7 +3059,7 @@ end if
 !preserve p1 for forecast time
 if (optio_log(nostatproc)) then
   roundtimerange(:)%timerange=254
-  roundtimerange(:)%p2=imiss
+  roundtimerange(:)%p2=0
 end if
 
 
@@ -3120,8 +3120,8 @@ do  itimerange=ntimerange+1,size(v7d_tmp%timerange)
 end do
 
 !copy with remove
-call copy(v7d_tmp,v7dout,miss=.true.)
-CALL delete (v7d_tmp)
+CALL copy(v7d_tmp,v7dout,miss=.TRUE.,lsort_timerange=.TRUE.,lsort_level=.TRUE.)
+CALL delete(v7d_tmp)
 
 !call display(v7dout)
 


### PR DESCRIPTION
Sistemazione dei timerange e riordinamento dopo una "rounding", (+ qualche ritocco alla tabella grib-bufr). Il problema era sorto perché dopo aver fatto una v7d_transform --rounding i timerange erano parzialmente disordinati. Ho anche scambiato l'ordine tra rounding e sort in v7d_transform ma è secondario.