### PR TITLE
Medcum

### DIFF
--- a/termolib/termo.F03
+++ b/termolib/termo.F03
@@ -36,6 +36,8 @@ subroutine register_termo(vfn)
   call fnregister(vfn,z_h_def())
   call fnregister(vfn,h_z_def())
   call fnregister(vfn,r_p_t2q_def())
+  call fnregister(vfn,swgwmo2swgsim_def())
+  call fnregister(vfn,swgsim2swgwmo_def())
 
 end subroutine register_termo
 
@@ -259,6 +261,44 @@ call init(swdir_swdif2swd_def,"swdir_swdif2swd",&
  [character(len=10) :: "B14194","B14195"],&
  [character(len=10) :: "B14018"],0,func=swdir_swdif2swd)
 end function swdir_swdif2swd_def
+
+
+subroutine swgwmo2swgsim(mybin,mybout,bin,bout,in,out)
+CHARACTER(len=10),intent(in) :: mybin(:)  !< vector table B  WMO input  in user's data
+CHARACTER(len=10),intent(in) :: mybout(:) !< vector table B  WMO output in user's data
+CHARACTER(len=10),intent(in) :: bin(:)    !< vector table B  WMO input used by function
+CHARACTER(len=10),intent(in) :: bout(:)   !< vector table B  WMO output used by function
+real, intent(in) :: in(:,:)
+real, intent(out) :: out(:,:)
+
+out(:,index_c(mybout, bout(1))) = in(:,index_c(mybin, bin(1)))
+
+end subroutine swgwmo2swgsim
+
+type(fnds) function swgwmo2swgsim_def()
+call init(swgwmo2swgsim_def,"swgwmo2swgsim",&
+ [character(len=10) :: "B14021"],&
+ [character(len=10) :: "B14198"],0,func=swgwmo2swgsim)
+end function swgwmo2swgsim_def
+
+
+subroutine swgsim2swgwmo(mybin,mybout,bin,bout,in,out)
+CHARACTER(len=10),intent(in) :: mybin(:)  !< vector table B  WMO input  in user's data
+CHARACTER(len=10),intent(in) :: mybout(:) !< vector table B  WMO output in user's data
+CHARACTER(len=10),intent(in) :: bin(:)    !< vector table B  WMO input used by function
+CHARACTER(len=10),intent(in) :: bout(:)   !< vector table B  WMO output used by function
+real, intent(in) :: in(:,:)
+real, intent(out) :: out(:,:)
+
+out(:,index_c(mybout, bout(1))) = in(:,index_c(mybin, bin(1)))
+
+end subroutine swgsim2swgwmo
+
+type(fnds) function swgsim2swgwmo_def()
+call init(swgsim2swgwmo_def,"swgsim2swgwmo",&
+ [character(len=10) :: "B14198"],&
+ [character(len=10) :: "B14021"],0,func=swgsim2swgwmo)
+end function swgsim2swgwmo_def
 
 
 subroutine  q_p_t2r(mybin,mybout,bin,bout,in,out)

--- a/vol7d/vol7d_class_compute.F90
+++ b/vol7d/vol7d_class_compute.F90
@@ -1042,7 +1042,9 @@ IF (COUNT(tr_mask) == 0) THEN
   RETURN
 ENDIF
 
+! copy required data and reset timerange
 CALL vol7d_copy(this, that, ltimerange=tr_mask)
+that%timerange(:)%timerange = stat_proc
 
 IF (stat_proc == 0) THEN ! average -> integral
   int_ratio = 1./REAL(that%timerange(:)%p2)

--- a/vol7d/vol7d_class_compute.F90
+++ b/vol7d/vol7d_class_compute.F90
@@ -1045,6 +1045,8 @@ ENDIF
 ! copy required data and reset timerange
 CALL vol7d_copy(this, that, ltimerange=tr_mask)
 that%timerange(:)%timerange = stat_proc
+! why next automatic f2003 allocation does not always work?
+ALLOCATE(int_ratio(SIZE(that%timerange)), int_ratiod(SIZE(that%timerange)))
 
 IF (stat_proc == 0) THEN ! average -> integral
   int_ratio = 1./REAL(that%timerange(:)%p2)

--- a/volgrid6d/volgrid6d_class_compute.F90
+++ b/volgrid6d/volgrid6d_class_compute.F90
@@ -661,13 +661,13 @@ END SUBROUTINE volgrid6d_recompute_stat_proc_diff
 !> Specialized method for statistically processing a set of data
 !! by integration/differentiation.
 !! This method performs statistical processing by integrating
-!! (accumulating) in time values having representing time-average
-!! rates or fluxes, (\a stat_proc_input=0 \a stat_proc=1) or by
-!! transforming a time-integrated (accumulated) value in a
-!! time-average rate or flux (\a stat_proc_input=1 \a stat_proc=0).
-!! analysis/observation or forecast timerange are processed. The only
-!! operation performed is respectively multiplying or dividing the
-!! values by the length of the time interval in seconds.
+!! (accumulating) in time values representing time-average rates or
+!! fluxes, (\a stat_proc_input=0 \a stat_proc=1) or by transforming a
+!! time-integrated (accumulated) value in a time-average rate or flux
+!! (\a stat_proc_input=1 \a stat_proc=0). Analysis/observation or
+!! forecast timeranges are processed. The only operation performed is
+!! respectively multiplying or dividing the values by the length of
+!! the time interval in seconds.
 !!
 !! The output \a that volgrid6d object contains elements from the
 !! original volume \a this satisfying the conditions
@@ -732,15 +732,10 @@ CALL compute_stat_proc_metamorph_common(stat_proc_input, this%timerange, stat_pr
 ! complete the definition of the output volume
 CALL volgrid6d_alloc_vol(that, decode=ASSOCIATED(this%voldati))
 
-ALLOCATE(int_ratio(SIZE(that%timerange)))
 IF (stat_proc == 0) THEN ! average -> integral
-  DO j = 1, SIZE(that%timerange)
-    int_ratio(j) = 1./REAL(that%timerange(j)%p2)
-  ENDDO
+  int_ratio = 1./REAL(that%timerange(:)%p2)
 ELSE ! cumulation
-  DO j = 1, SIZE(that%timerange)
-    int_ratio(j) = REAL(that%timerange(j)%p2)
-  ENDDO
+  int_ratio = REAL(that%timerange(:)%p2)
 ENDIF
 
 DO i6 = 1, SIZE(this%var)


### PR DESCRIPTION
Implement time integration/differentiation for sparse data with `--comp-stat-proc=0:1` or `--comp-stat-proc=1:0`.
Allow to convert identically radiation variables, from B14021 to B14198 and viceversa.
