### PR TITLE
restore reference time with time_definition 0

### DIFF
--- a/vol7d/vol7d_serialize_dballe_class.F03
+++ b/vol7d/vol7d_serialize_dballe_class.F03
@@ -532,6 +532,14 @@ DO WHILE(linei%next())
     end do
   enddo
 
+! restore reference time if changed because of time definition
+! otherwise strange things happen
+  if (this%v7d%time_definition == 0) then
+    metaanddata%metadata%datetime%datetime = &
+     metaanddata%metadata%datetime%datetime - &
+     timedelta_new(sec=metaanddata%metadata%timerange%vol7d_timerange%p1)
+  end if
+
 END DO
 
 END SUBROUTINE vol7d_serialize_export


### PR DESCRIPTION
When exporting a volume with time definition 0 (reference time) do dba the output (verification) time in bufr is wrong, this seems to fix. Time definition 0 was probably never tested.