### PR TITLE
Versioning doc and bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ framework for compiling the main libsim dependencies and libsim
 itself, as well as an universal binary package suitable to be
 installed on a generic state-of-the-art x86_64 Linux system.
 
+Versioning
+----------
+
+From version 7.0.0, libsim follows [semver 2.0](https://semver.org/) for API
+and ABI changes. The library version (`-version-info`) follows the [libtools
+conventions](https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html).
+
 Documentation
 -------------
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,12 +1,12 @@
 dnl Process this file with autoconf to produce a configure script.
 
-AC_INIT(libsim, 6.5.3, [dcesari@arpae.it])
+AC_INIT(libsim, 7.0.0, [dcesari@arpae.it])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_SRCDIR([configure.ac])
 AM_INIT_AUTOMAKE([foreign])
 AC_CONFIG_MACRO_DIR([m4])
 
-LIBSIM_VERSION_INFO=`echo $VERSION | awk -F. '{ printf "%d:%d:%d", $1+$2, $3, $2 }'`
+LIBSIM_VERSION_INFO="12:0:0"
 AC_SUBST(LIBSIM_VERSION_INFO)
 
 AC_LANG([C])


### PR DESCRIPTION
PR to follow semver https://semver.org/ for the package version and libtool https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html for the library version. The package version reflects changes both on API and ABI.