### PR TITLE
Fixed shell compatibility

### DIFF
--- a/bin/dba_qcfilter_test.sh
+++ b/bin/dba_qcfilter_test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-function failed(){
+failed() {
 echo "cmp failled"
 exit 1
 }

--- a/vol7d/dballe_test.sh
+++ b/vol7d/dballe_test.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 set -e
 
-function failed(){
+failed() {
     echo "cmp failed"
     exit 1
 }
 
-function cleanup(){
+cleanup() {
     rm -f dballe_test2_memdb.bufr dballe_test_copy1f.bufr dballe_test_copy1fmem.bufr dballe_test.sqlite dballe_test2.bufr dballe_test3.bufr
 }
 

--- a/vol7d/vol7d_dballe_test.sh
+++ b/vol7d/vol7d_dballe_test.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 set -e
 
-function failed(){
+failed() {
     echo "cmp failed"
     exit 1
 }
 
-function cleanup(){
+cleanup() {
     rm -f vol7d_dballe_test_out.bufr 
 }
 


### PR DESCRIPTION
Here's a pull request that fixes the syntax of some shellscripts to work also when /bin/sh is not bash (function is bash specific)